### PR TITLE
Fix/navigation and profile page layout

### DIFF
--- a/src/lib/components/atoms/ExpandedContent.svelte
+++ b/src/lib/components/atoms/ExpandedContent.svelte
@@ -33,7 +33,7 @@
 		</span>
 	</button>
 	{#if expanded}
-		<div transition:slide class="pt-1">
+		<div transition:slide|local class="pt-1">
 			<slot name="content" />
 		</div>
 	{/if}

--- a/src/routes/profil/+layout.svelte
+++ b/src/routes/profil/+layout.svelte
@@ -3,7 +3,7 @@
 	import Sidebar from '$lib/features/sidebar/Sidebar.svelte'
 </script>
 
-<div class="pl-[max(15vw,15rem)] h-screen">
+<div class="pl-[max(3vw,3rem)] h-screen">
 	<Sidebar withWorkspace={false} />
 	<SearchBar />
 	<slot />


### PR DESCRIPTION
[fix: navigation being broken after an expanded content element was clicked on](https://github.com/SimplyTeam/SimplyTeam-Front/commit/4334e8acf6fd5bdedf8e0d3cef192c95de41c918) 

[fix: profil page layout](https://github.com/SimplyTeam/SimplyTeam-Front/commit/be4ce8dc4b4b8ee1428969367f6602ecf6645d04)